### PR TITLE
chore: fix biome warning for unused variable

### DIFF
--- a/src/http-clients/axios-adapter.js
+++ b/src/http-clients/axios-adapter.js
@@ -20,10 +20,10 @@ class AxiosHttpClientAdapter {
 
   /**
    *
-   * @param response
+   * @param _response
    * @return {CanAdapterHandle}
    */
-  static canHandle(response) {
+  static canHandle(_response) {
     // TODO - implement
     return 'maybe';
   }


### PR DESCRIPTION
Fixes biome warning on unused variable.

Old output:
```bash
npm run check

> expect-http-client-matchers@0.0.0-development check
> npx @biomejs/biome check

/Users/tamirmousari/dev/expect-axios-matchers/src/http-clients/axios-adapter.js:26:20 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━

  ⚠ This parameter is unused.
  
    24 │    * @return {CanAdapterHandle}
    25 │    */
  > 26 │   static canHandle(response) {
       │                    ^^^^^^^^
    27 │     // TODO - implement
    28 │     return 'maybe';
  
  ℹ Unused variables usually are result of incomplete refactoring, typos and other source of bugs.
  
  ℹ Unsafe fix: If this is intentional, prepend response with an underscore.
  
    24 24 │      * @return {CanAdapterHandle}
    25 25 │      */
    26    │ - ··static·canHandle(response)·{
       26 │ + ··static·canHandle(_response)·{
    27 27 │       // TODO - implement
    28 28 │       return 'maybe';
  

Checked 172 files in 22ms. No fixes needed.
Found 1 warning.
```

New output:
```bash
npm run check

> expect-http-client-matchers@0.0.0-development check
> npx @biomejs/biome check

Checked 172 files in 28ms. No fixes needed.
```