### PR TITLE
fix: rename `toHaveBodyEqualsTo` to `toHaveBodyEquals`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Additional expect matchers for http clients (e.g. Axios), supports `jest`, `vite
     - [.toHaveInsufficientStorageStatus()](#tohaveinsufficientstoragestatus)
     - [.toHaveNetworkAuthenticationRequiredStatus()](#tohavenetworkauthenticationrequiredstatus)
   - [.toHaveHeader(`<header name>`[, `<header value>`])](#tohaveheaderheader-name-header-value)
-  - [.toHaveBodyEqualsTo(`<body>`)](#tohavebodyequalstobody)
+  - [.toHaveBodyEquals(`<body>`)](#tohavebodyequalsbody)
 
 
 ## Installation
@@ -1353,19 +1353,19 @@ test('passes when using .toHaveHeader() with expected value', async () => {
 });
 ```
 
-#### .toHaveBodyEqualsTo(`<body>`)
+#### .toHaveBodyEquals(`<body>`)
 
-Use `.toHaveBodyEqualsTo` when checking if response body is equal to the expected body
+Use `.toHaveBodyEquals` when checking if response body is equal to the expected body
 
 ```js
 test('passes when response body match the expected body', async () => {
     const response = await axios.get('https://httpstat.us/200');
-    expect(response).toHaveBodyEqualsTo('200 OK');
+    expect(response).toHaveBodyEquals('200 OK');
 });
 
-test('passes when using .not.toHaveBodyEqualsTo() with different body', async () => {
+test('passes when using .not.toHaveBodyEquals() with different body', async () => {
   const response = await axios.get('https://httpstat.us/200');
-  expect(response).not.toHaveBodyEqualsTo('404 NOT FOUND');
+  expect(response).not.toHaveBodyEquals('404 NOT FOUND');
 });
 ```
 

--- a/src/matchers/data/index.js
+++ b/src/matchers/data/index.js
@@ -1,5 +1,5 @@
-const { toHaveBodyEqualsTo } = require('./toHaveBodyEqualsTo');
+const { toHaveBodyEquals } = require('./toHaveBodyEquals');
 
 module.exports = {
-  toHaveBodyEqualsTo,
+  toHaveBodyEquals,
 };

--- a/src/matchers/data/toHaveBodyEquals.js
+++ b/src/matchers/data/toHaveBodyEquals.js
@@ -30,7 +30,7 @@ function getJSONBody(adapter) {
 /**
  * @this {import('expect').MatcherUtils}
  */
-function toHaveBodyEqualsTo(actual, expectedValue) {
+function toHaveBodyEquals(actual, expectedValue) {
   const { matcherHint, printExpected, printDiffOrStringify, printReceived } = this.utils;
 
   const adapter = getMatchingAdapter(actual);
@@ -78,4 +78,4 @@ function toHaveBodyEqualsTo(actual, expectedValue) {
   };
 }
 
-module.exports = { toHaveBodyEqualsTo };
+module.exports = { toHaveBodyEquals };

--- a/test/matchers/data/toHaveBodyEqualsTo.test.js
+++ b/test/matchers/data/toHaveBodyEqualsTo.test.js
@@ -1,13 +1,13 @@
-const { toHaveBodyEqualsTo } = require('../../../src');
+const { toHaveBodyEquals } = require('../../../src');
 const { describe, before, it } = require('node:test');
 const { buildServer } = require('../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');
 const { getServerUrl } = require('../../helpers/server-helper');
 const { testClients } = require('../../helpers/supported-clients');
 
-expect.extend({ toHaveBodyEqualsTo });
+expect.extend({ toHaveBodyEquals });
 
-describe('(.not).toHaveBodyEqualsTo', () => {
+describe('(.not).toHaveBodyEquals', () => {
   let apiUrl = getServerUrl();
 
   before(async () => {
@@ -16,7 +16,7 @@ describe('(.not).toHaveBodyEqualsTo', () => {
 
   for (const testClient of testClients) {
     describe(`using ${testClient.name}`, () => {
-      describe('.toHaveBodyEqualsTo', () => {
+      describe('.toHaveBodyEquals', () => {
         it('should pass when the expected data match and body is json', async () => {
           const response = await testClient.post(`${apiUrl}/body`, {
             contentType: 'application/json',
@@ -31,7 +31,7 @@ describe('(.not).toHaveBodyEqualsTo', () => {
             },
           });
 
-          expect(response).toHaveBodyEqualsTo({
+          expect(response).toHaveBodyEquals({
             a: '1',
             b: 2,
             c: true,
@@ -42,7 +42,7 @@ describe('(.not).toHaveBodyEqualsTo', () => {
           });
 
           expect({ response }).toEqual({
-            response: expect.toHaveBodyEqualsTo({
+            response: expect.toHaveBodyEquals({
               a: '1',
               b: 2,
               c: true,
@@ -60,10 +60,10 @@ describe('(.not).toHaveBodyEqualsTo', () => {
             data: 'Hello World',
           });
 
-          expect(response).toHaveBodyEqualsTo('Hello World');
+          expect(response).toHaveBodyEquals('Hello World');
 
           expect({ response }).toEqual({
-            response: expect.toHaveBodyEqualsTo('Hello World'),
+            response: expect.toHaveBodyEquals('Hello World'),
           });
         });
 
@@ -81,7 +81,7 @@ describe('(.not).toHaveBodyEqualsTo', () => {
             },
           });
 
-          expect(response).toHaveBodyEqualsTo(
+          expect(response).toHaveBodyEquals(
             expect.objectContaining({
               b: expect.any(Number),
               c: true,
@@ -89,7 +89,7 @@ describe('(.not).toHaveBodyEqualsTo', () => {
           );
 
           expect({ response }).toEqual({
-            response: expect.toHaveBodyEqualsTo(
+            response: expect.toHaveBodyEquals(
               expect.objectContaining({
                 b: expect.any(Number),
                 c: true,
@@ -110,7 +110,7 @@ describe('(.not).toHaveBodyEqualsTo', () => {
           });
 
           try {
-            expect(response).toHaveBodyEqualsTo({
+            expect(response).toHaveBodyEquals({
               a: '1',
               b: 2,
               c: true,
@@ -125,7 +125,7 @@ describe('(.not).toHaveBodyEqualsTo', () => {
 
           expect(() =>
             expect({ response }).toEqual({
-              response: expect.toHaveBodyEqualsTo({
+              response: expect.toHaveBodyEquals({
                 a: '1',
                 b: 2,
                 c: true,
@@ -148,14 +148,14 @@ describe('(.not).toHaveBodyEqualsTo', () => {
           });
 
           try {
-            expect(response).toHaveBodyEqualsTo('Someone');
+            expect(response).toHaveBodyEquals('Someone');
           } catch (e) {
             t.assert.snapshot(e);
           }
 
           expect(() =>
             expect({ response }).toEqual({
-              response: expect.toHaveBodyEqualsTo('Someone'),
+              response: expect.toHaveBodyEquals('Someone'),
             }),
           ).toThrowError(JestAssertionError);
         });
@@ -178,7 +178,7 @@ describe('(.not).toHaveBodyEqualsTo', () => {
           });
 
           try {
-            expect(response).toHaveBodyEqualsTo(
+            expect(response).toHaveBodyEquals(
               expect.objectContaining({
                 a: expect.any(Number),
               }),
@@ -189,7 +189,7 @@ describe('(.not).toHaveBodyEqualsTo', () => {
 
           expect(() =>
             expect({ response }).toEqual({
-              response: expect.toHaveBodyEqualsTo(
+              response: expect.toHaveBodyEquals(
                 expect.objectContaining({
                   a: expect.any(Number),
                 }),
@@ -210,20 +210,20 @@ describe('(.not).toHaveBodyEqualsTo', () => {
           });
 
           try {
-            expect(response).toHaveBodyEqualsTo('Hello World');
+            expect(response).toHaveBodyEquals('Hello World');
           } catch (e) {
             t.assert.snapshot(e);
           }
 
           expect(() =>
             expect({ response }).toEqual({
-              response: expect.toHaveBodyEqualsTo('Hello World'),
+              response: expect.toHaveBodyEquals('Hello World'),
             }),
           ).toThrowError(JestAssertionError);
         });
       });
 
-      describe('.not.toHaveBodyEqualsTo', () => {
+      describe('.not.toHaveBodyEquals', () => {
         it('should pass when the json data does not match', async () => {
           const response = await testClient.post(`${apiUrl}/body`, {
             contentType: 'application/json',
@@ -232,7 +232,7 @@ describe('(.not).toHaveBodyEqualsTo', () => {
             },
           });
 
-          expect(response).not.toHaveBodyEqualsTo({
+          expect(response).not.toHaveBodyEquals({
             a: '1',
             b: 2,
             c: true,
@@ -243,7 +243,7 @@ describe('(.not).toHaveBodyEqualsTo', () => {
           });
 
           expect({ response }).toEqual({
-            response: expect.not.toHaveBodyEqualsTo({
+            response: expect.not.toHaveBodyEquals({
               a: '1',
               b: 2,
               c: true,
@@ -261,10 +261,10 @@ describe('(.not).toHaveBodyEqualsTo', () => {
             data: 'Hello World',
           });
 
-          expect(response).not.toHaveBodyEqualsTo('Someone');
+          expect(response).not.toHaveBodyEquals('Someone');
 
           expect({ response }).toEqual({
-            response: expect.not.toHaveBodyEqualsTo('Someone'),
+            response: expect.not.toHaveBodyEquals('Someone'),
           });
         });
 
@@ -282,14 +282,14 @@ describe('(.not).toHaveBodyEqualsTo', () => {
             },
           });
 
-          expect(response).not.toHaveBodyEqualsTo(
+          expect(response).not.toHaveBodyEquals(
             expect.objectContaining({
               a: expect.any(Number),
             }),
           );
 
           expect({ response }).toEqual({
-            response: expect.not.toHaveBodyEqualsTo(
+            response: expect.not.toHaveBodyEquals(
               expect.objectContaining({
                 a: expect.any(Number),
               }),
@@ -305,9 +305,9 @@ describe('(.not).toHaveBodyEqualsTo', () => {
             },
           });
 
-          expect(response).not.toHaveBodyEqualsTo('Hello World');
+          expect(response).not.toHaveBodyEquals('Hello World');
           expect({ response }).toEqual({
-            response: expect.not.toHaveBodyEqualsTo('Hello World'),
+            response: expect.not.toHaveBodyEquals('Hello World'),
           });
         });
 
@@ -329,7 +329,7 @@ describe('(.not).toHaveBodyEqualsTo', () => {
           });
 
           try {
-            expect(response).not.toHaveBodyEqualsTo({
+            expect(response).not.toHaveBodyEquals({
               a: '1',
               b: 2,
               c: true,
@@ -344,7 +344,7 @@ describe('(.not).toHaveBodyEqualsTo', () => {
 
           expect(() =>
             expect({ response }).toEqual({
-              response: expect.not.toHaveBodyEqualsTo({
+              response: expect.not.toHaveBodyEquals({
                 a: '1',
                 b: 2,
                 c: true,
@@ -367,14 +367,14 @@ describe('(.not).toHaveBodyEqualsTo', () => {
           });
 
           try {
-            expect(response).not.toHaveBodyEqualsTo('Hello World');
+            expect(response).not.toHaveBodyEquals('Hello World');
           } catch (e) {
             t.assert.snapshot(e);
           }
 
           expect(() =>
             expect({ response }).toEqual({
-              response: expect.not.toHaveBodyEqualsTo('Hello World'),
+              response: expect.not.toHaveBodyEquals('Hello World'),
             }),
           ).toThrowError(JestAssertionError);
         });
@@ -397,7 +397,7 @@ describe('(.not).toHaveBodyEqualsTo', () => {
           });
 
           try {
-            expect(response).not.toHaveBodyEqualsTo(
+            expect(response).not.toHaveBodyEquals(
               expect.objectContaining({
                 b: expect.any(Number),
                 c: true,
@@ -409,7 +409,7 @@ describe('(.not).toHaveBodyEqualsTo', () => {
 
           expect(() =>
             expect({ response }).toEqual({
-              response: expect.not.toHaveBodyEqualsTo(
+              response: expect.not.toHaveBodyEquals(
                 expect.objectContaining({
                   b: expect.any(Number),
                   c: true,

--- a/test/matchers/data/toHaveBodyEqualsTo.test.js.snapshot
+++ b/test/matchers/data/toHaveBodyEqualsTo.test.js.snapshot
@@ -1,4 +1,4 @@
-exports[`(.not).toHaveBodyEqualsTo > using axios > .not.toHaveBodyEqualsTo > should fail when the expected data match and body is json 1`] = `
+exports[`(.not).toHaveBodyEquals > using axios > .not.toHaveBodyEquals > should fail when the expected data match and body is json 1`] = `
 <dim>expect(</intensity><red>received</color><dim>).not.toHaveDataEqualsTo(</intensity><green>expected</color><dim>)</intensity>
 
 Expected request to not have data:
@@ -19,7 +19,7 @@ response is:
 }
 `;
 
-exports[`(.not).toHaveBodyEqualsTo > using axios > .not.toHaveBodyEqualsTo > should fail when the expected data match and body is json when using asymmetric matchers in the data 1`] = `
+exports[`(.not).toHaveBodyEquals > using axios > .not.toHaveBodyEquals > should fail when the expected data match and body is json when using asymmetric matchers in the data 1`] = `
 <dim>expect(</intensity><red>received</color><dim>).not.toHaveDataEqualsTo(</intensity><green>expected</color><dim>)</intensity>
 
 Expected request to not have data:
@@ -40,7 +40,7 @@ response is:
 }
 `;
 
-exports[`(.not).toHaveBodyEqualsTo > using axios > .not.toHaveBodyEqualsTo > should fail when the expected data match and body is text 1`] = `
+exports[`(.not).toHaveBodyEquals > using axios > .not.toHaveBodyEquals > should fail when the expected data match and body is text 1`] = `
 <dim>expect(</intensity><red>received</color><dim>).not.toHaveDataEqualsTo(</intensity><green>expected</color><dim>)</intensity>
 
 Expected request to not have data:
@@ -61,7 +61,7 @@ response is:
 }
 `;
 
-exports[`(.not).toHaveBodyEqualsTo > using axios > .toHaveBodyEqualsTo > should fail when the json data does not match 1`] = `
+exports[`(.not).toHaveBodyEquals > using axios > .toHaveBodyEquals > should fail when the json data does not match 1`] = `
 <dim>expect(</intensity><red>received</color><dim>).toHaveDataEqualsTo(</intensity><green>expected</color><dim>)</intensity>
 
 Expected request to have data:
@@ -92,7 +92,7 @@ response is:
 }
 `;
 
-exports[`(.not).toHaveBodyEqualsTo > using axios > .toHaveBodyEqualsTo > should fail when the json data does not match when using asymmetric matchers in the data 1`] = `
+exports[`(.not).toHaveBodyEquals > using axios > .toHaveBodyEquals > should fail when the json data does not match when using asymmetric matchers in the data 1`] = `
 <dim>expect(</intensity><red>received</color><dim>).toHaveDataEqualsTo(</intensity><green>expected</color><dim>)</intensity>
 
 Expected request to have data:
@@ -124,7 +124,7 @@ response is:
 }
 `;
 
-exports[`(.not).toHaveBodyEqualsTo > using axios > .toHaveBodyEqualsTo > should fail when the response body type does not match 1`] = `
+exports[`(.not).toHaveBodyEquals > using axios > .toHaveBodyEquals > should fail when the response body type does not match 1`] = `
 <dim>expect(</intensity><red>received</color><dim>).toHaveDataEqualsTo(</intensity><green>expected</color><dim>)</intensity>
 
 Expected request to have data:
@@ -144,7 +144,7 @@ response is:
 }
 `;
 
-exports[`(.not).toHaveBodyEqualsTo > using axios > .toHaveBodyEqualsTo > should fail when the text data does not match 1`] = `
+exports[`(.not).toHaveBodyEquals > using axios > .toHaveBodyEquals > should fail when the text data does not match 1`] = `
 <dim>expect(</intensity><red>received</color><dim>).toHaveDataEqualsTo(</intensity><green>expected</color><dim>)</intensity>
 
 Expected request to have data:

--- a/types-test/expect-type-tests/types.test.ts
+++ b/types-test/expect-type-tests/types.test.ts
@@ -355,20 +355,20 @@ async function run() {
     expect(res).toEqual(expect.not.toHaveHeader(expect.any(String), 'hello'));
   }
 
-  expect(res).toHaveBodyEqualsTo({ foo: 'bar' });
-  expect(res).not.toHaveBodyEqualsTo({ foo: 'bar' });
-  expect(res).toEqual(expect.toHaveBodyEqualsTo({ foo: 'bar' }));
-  expect(res).toEqual(expect.not.toHaveBodyEqualsTo({ foo: 'bar' }));
+  expect(res).toHaveBodyEquals({ foo: 'bar' });
+  expect(res).not.toHaveBodyEquals({ foo: 'bar' });
+  expect(res).toEqual(expect.toHaveBodyEquals({ foo: 'bar' }));
+  expect(res).toEqual(expect.not.toHaveBodyEquals({ foo: 'bar' }));
 
-  expect(res).toHaveBodyEqualsTo('some text');
-  expect(res).not.toHaveBodyEqualsTo('some text');
-  expect(res).toEqual(expect.toHaveBodyEqualsTo('some text'));
-  expect(res).toEqual(expect.not.toHaveBodyEqualsTo('some text'));
+  expect(res).toHaveBodyEquals('some text');
+  expect(res).not.toHaveBodyEquals('some text');
+  expect(res).toEqual(expect.toHaveBodyEquals('some text'));
+  expect(res).toEqual(expect.not.toHaveBodyEquals('some text'));
 
-  expect(res).toHaveBodyEqualsTo(expect.anything());
-  expect(res).not.toHaveBodyEqualsTo(expect.anything());
-  expect(res).toEqual(expect.toHaveBodyEqualsTo(expect.anything()));
-  expect(res).toEqual(expect.not.toHaveBodyEqualsTo(expect.anything()));
+  expect(res).toHaveBodyEquals(expect.anything());
+  expect(res).not.toHaveBodyEquals(expect.anything());
+  expect(res).toEqual(expect.toHaveBodyEquals(expect.anything()));
+  expect(res).toEqual(expect.not.toHaveBodyEquals(expect.anything()));
 }
 
 run();

--- a/types-test/jest-all-type-tests/types.test.ts
+++ b/types-test/jest-all-type-tests/types.test.ts
@@ -354,20 +354,20 @@ async function run() {
     expect(res).toEqual(expect.not.toHaveHeader({}, 'hello'));
   }
 
-  expect(res).toHaveBodyEqualsTo({ foo: 'bar' });
-  expect(res).not.toHaveBodyEqualsTo({ foo: 'bar' });
-  expect(res).toEqual(expect.toHaveBodyEqualsTo({ foo: 'bar' }));
-  expect(res).toEqual(expect.not.toHaveBodyEqualsTo({ foo: 'bar' }));
+  expect(res).toHaveBodyEquals({ foo: 'bar' });
+  expect(res).not.toHaveBodyEquals({ foo: 'bar' });
+  expect(res).toEqual(expect.toHaveBodyEquals({ foo: 'bar' }));
+  expect(res).toEqual(expect.not.toHaveBodyEquals({ foo: 'bar' }));
 
-  expect(res).toHaveBodyEqualsTo('some text');
-  expect(res).not.toHaveBodyEqualsTo('some text');
-  expect(res).toEqual(expect.toHaveBodyEqualsTo('some text'));
-  expect(res).toEqual(expect.not.toHaveBodyEqualsTo('some text'));
+  expect(res).toHaveBodyEquals('some text');
+  expect(res).not.toHaveBodyEquals('some text');
+  expect(res).toEqual(expect.toHaveBodyEquals('some text'));
+  expect(res).toEqual(expect.not.toHaveBodyEquals('some text'));
 
-  expect(res).toHaveBodyEqualsTo(expect.anything());
-  expect(res).not.toHaveBodyEqualsTo(expect.anything());
-  expect(res).toEqual(expect.toHaveBodyEqualsTo(expect.anything()));
-  expect(res).toEqual(expect.not.toHaveBodyEqualsTo(expect.anything()));
+  expect(res).toHaveBodyEquals(expect.anything());
+  expect(res).not.toHaveBodyEquals(expect.anything());
+  expect(res).toEqual(expect.toHaveBodyEquals(expect.anything()));
+  expect(res).toEqual(expect.not.toHaveBodyEquals(expect.anything()));
 }
 
 run();

--- a/types-test/jest-partial-type-tests/types.test.ts
+++ b/types-test/jest-partial-type-tests/types.test.ts
@@ -354,20 +354,20 @@ async function run() {
     expect(res).toEqual(expect.not.toHaveHeader({}, 'hello'));
   }
 
-  expect(res).toHaveBodyEqualsTo({ foo: 'bar' });
-  expect(res).not.toHaveBodyEqualsTo({ foo: 'bar' });
-  expect(res).toEqual(expect.toHaveBodyEqualsTo({ foo: 'bar' }));
-  expect(res).toEqual(expect.not.toHaveBodyEqualsTo({ foo: 'bar' }));
+  expect(res).toHaveBodyEquals({ foo: 'bar' });
+  expect(res).not.toHaveBodyEquals({ foo: 'bar' });
+  expect(res).toEqual(expect.toHaveBodyEquals({ foo: 'bar' }));
+  expect(res).toEqual(expect.not.toHaveBodyEquals({ foo: 'bar' }));
 
-  expect(res).toHaveBodyEqualsTo('some text');
-  expect(res).not.toHaveBodyEqualsTo('some text');
-  expect(res).toEqual(expect.toHaveBodyEqualsTo('some text'));
-  expect(res).toEqual(expect.not.toHaveBodyEqualsTo('some text'));
+  expect(res).toHaveBodyEquals('some text');
+  expect(res).not.toHaveBodyEquals('some text');
+  expect(res).toEqual(expect.toHaveBodyEquals('some text'));
+  expect(res).toEqual(expect.not.toHaveBodyEquals('some text'));
 
-  expect(res).toHaveBodyEqualsTo(expect.anything());
-  expect(res).not.toHaveBodyEqualsTo(expect.anything());
-  expect(res).toEqual(expect.toHaveBodyEqualsTo(expect.anything()));
-  expect(res).toEqual(expect.not.toHaveBodyEqualsTo(expect.anything()));
+  expect(res).toHaveBodyEquals(expect.anything());
+  expect(res).not.toHaveBodyEquals(expect.anything());
+  expect(res).toEqual(expect.toHaveBodyEquals(expect.anything()));
+  expect(res).toEqual(expect.not.toHaveBodyEquals(expect.anything()));
 }
 
 run();

--- a/types-test/vitest-all-type-tests/types.test.ts
+++ b/types-test/vitest-all-type-tests/types.test.ts
@@ -354,20 +354,20 @@ async function run() {
     expect(res).toEqual(expect.not.toHaveHeader({}, 'hello'));
   }
 
-  expect(res).toHaveBodyEqualsTo({ foo: 'bar' });
-  expect(res).not.toHaveBodyEqualsTo({ foo: 'bar' });
-  expect(res).toEqual(expect.toHaveBodyEqualsTo({ foo: 'bar' }));
-  expect(res).toEqual(expect.not.toHaveBodyEqualsTo({ foo: 'bar' }));
+  expect(res).toHaveBodyEquals({ foo: 'bar' });
+  expect(res).not.toHaveBodyEquals({ foo: 'bar' });
+  expect(res).toEqual(expect.toHaveBodyEquals({ foo: 'bar' }));
+  expect(res).toEqual(expect.not.toHaveBodyEquals({ foo: 'bar' }));
 
-  expect(res).toHaveBodyEqualsTo('some text');
-  expect(res).not.toHaveBodyEqualsTo('some text');
-  expect(res).toEqual(expect.toHaveBodyEqualsTo('some text'));
-  expect(res).toEqual(expect.not.toHaveBodyEqualsTo('some text'));
+  expect(res).toHaveBodyEquals('some text');
+  expect(res).not.toHaveBodyEquals('some text');
+  expect(res).toEqual(expect.toHaveBodyEquals('some text'));
+  expect(res).toEqual(expect.not.toHaveBodyEquals('some text'));
 
-  expect(res).toHaveBodyEqualsTo(expect.anything());
-  expect(res).not.toHaveBodyEqualsTo(expect.anything());
-  expect(res).toEqual(expect.toHaveBodyEqualsTo(expect.anything()));
-  expect(res).toEqual(expect.not.toHaveBodyEqualsTo(expect.anything()));
+  expect(res).toHaveBodyEquals(expect.anything());
+  expect(res).not.toHaveBodyEquals(expect.anything());
+  expect(res).toEqual(expect.toHaveBodyEquals(expect.anything()));
+  expect(res).toEqual(expect.not.toHaveBodyEquals(expect.anything()));
 }
 
 run();

--- a/types-test/vitest-partial-type-tests/types.test.ts
+++ b/types-test/vitest-partial-type-tests/types.test.ts
@@ -354,20 +354,20 @@ async function run() {
     expect(res).toEqual(expect.not.toHaveHeader({}, 'hello'));
   }
 
-  expect(res).toHaveBodyEqualsTo({ foo: 'bar' });
-  expect(res).not.toHaveBodyEqualsTo({ foo: 'bar' });
-  expect(res).toEqual(expect.toHaveBodyEqualsTo({ foo: 'bar' }));
-  expect(res).toEqual(expect.not.toHaveBodyEqualsTo({ foo: 'bar' }));
+  expect(res).toHaveBodyEquals({ foo: 'bar' });
+  expect(res).not.toHaveBodyEquals({ foo: 'bar' });
+  expect(res).toEqual(expect.toHaveBodyEquals({ foo: 'bar' }));
+  expect(res).toEqual(expect.not.toHaveBodyEquals({ foo: 'bar' }));
 
-  expect(res).toHaveBodyEqualsTo('some text');
-  expect(res).not.toHaveBodyEqualsTo('some text');
-  expect(res).toEqual(expect.toHaveBodyEqualsTo('some text'));
-  expect(res).toEqual(expect.not.toHaveBodyEqualsTo('some text'));
+  expect(res).toHaveBodyEquals('some text');
+  expect(res).not.toHaveBodyEquals('some text');
+  expect(res).toEqual(expect.toHaveBodyEquals('some text'));
+  expect(res).toEqual(expect.not.toHaveBodyEquals('some text'));
 
-  expect(res).toHaveBodyEqualsTo(expect.anything());
-  expect(res).not.toHaveBodyEqualsTo(expect.anything());
-  expect(res).toEqual(expect.toHaveBodyEqualsTo(expect.anything()));
-  expect(res).toEqual(expect.not.toHaveBodyEqualsTo(expect.anything()));
+  expect(res).toHaveBodyEquals(expect.anything());
+  expect(res).not.toHaveBodyEquals(expect.anything());
+  expect(res).toEqual(expect.toHaveBodyEquals(expect.anything()));
+  expect(res).toEqual(expect.not.toHaveBodyEquals(expect.anything()));
 }
 
 run();

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -313,10 +313,10 @@ export interface CustomMatchers<R> extends Record<string, any> {
   toHaveHeader(headerName: string, expectedHeaderValue?: unknown): R;
 
   /**
-   * Use .toHaveDataEqualsTo when checking if the response body is equal to the expected body.
+   * Use .toHaveBodyEquals when checking if the response body is equal to the expected body.
    * @param {unknown} expectedBody the expected body to match with
    **/
-  toHaveBodyEqualsTo(expectedBody: unknown): R;
+  toHaveBodyEquals(expectedBody: unknown): R;
 }
 
 // noinspection JSUnusedGlobalSymbols
@@ -635,8 +635,8 @@ export interface SharedMatchers<R> {
   toHaveHeader(headerName: string, expectedHeaderValue?: unknown): R;
 
   /**
-   * Use .toHaveBodyEqualsTo when checking if the response body is equal to the expected body.
+   * Use .toHaveBodyEquals when checking if the response body is equal to the expected body.
    * @param {unknown} expectedBody the expected body to match with
    **/
-  toHaveBodyEqualsTo(expectedBody: unknown): R;
+  toHaveBodyEquals(expectedBody: unknown): R;
 }


### PR DESCRIPTION
Not marking as breaking change as we don't have any users yet, otherwise this would be breaking change