### PR TITLE
fix(export): change how specific matchers are consumed

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,12 @@ yarn add -D expect-http-client-matchers
 import {expect} from 'expect';
 
 // add all expect-http-client-matchers matchers
-import * as matchers from 'expect-http-client-matchers';
+import {matchers} from 'expect-http-client-matchers';
 expect.extend(matchers);
 
 // or just add specific matchers
-import { toBeSuccessful, toHave2xxStatus } from 'expect-http-client-matchers';
-expect.extend({ toBeSuccessful, toHave2xxStatus });
+import { matchers } from 'expect-http-client-matchers';
+const { toBeSuccessful, toHave2xxStatus } = matchers;
 ```
 
 #### Typescript
@@ -134,12 +134,12 @@ import 'expect-http-client-matchers/expect.d.ts';
 // ./testSetup.js
 
 // add all expect-http-client-matchers matchers
-import * as matchers from 'expect-http-client-matchers';
+import { matchers } from 'expect-http-client-matchers';
 expect.extend(matchers);
 
 // or just add specific matchers
-import { toBeSuccessful, toHave2xxStatus } from 'expect-http-client-matchers';
-expect.extend({ toBeSuccessful, toHave2xxStatus });
+import { matchers } from 'expect-http-client-matchers';
+const { toBeSuccessful, toHave2xxStatus } = matchers;
 ```
 
 Add your setup script to your Vitest `setupFiles` configuration. [See for help](https://vitest.dev/config/#setupfiles)
@@ -198,11 +198,12 @@ and add that file to the `"files"` list inside your `tsconfig.json`
 // ./testSetup.js
 
 // add all expect-http-client-matchers matchers
-import * as matchers from 'expect-http-client-matchers';
+import { matchers } from 'expect-http-client-matchers';
 expect.extend(matchers);
 
 // or just add specific matchers
-import { toBeSuccessful, toHave2xxStatus } from 'expect-http-client-matchers';
+import { matchers } from 'expect-http-client-matchers';
+const { toBeSuccessful, toHave2xxStatus } = matchers;
 expect.extend({ toBeSuccessful, toHave2xxStatus });
 ```
 

--- a/all.js
+++ b/all.js
@@ -1,4 +1,4 @@
-const matchers = require('./src');
+const { matchers } = require('./src');
 
 const globalExpect = global.expect;
 if (globalExpect !== undefined) {
@@ -7,6 +7,6 @@ if (globalExpect !== undefined) {
   throw new Error(
     'Unable to find global expect. ' +
       'Please check you have added expect-http-client-matchers correctly.' +
-      'See https://github.com/rluvaton/expect-axios-matchers#setup for help.',
+      'See https://github.com/rluvaton/expect-http-client-matchers#setup for help.',
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
 const matchers = require('./matchers');
 
-module.exports = matchers;
+module.exports = {
+    matchers,
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const matchers = require('./matchers');
 
 module.exports = {
-    matchers,
-}
+  matchers,
+};

--- a/test/matchers/data/toHaveBodyEquals.test.js
+++ b/test/matchers/data/toHaveBodyEquals.test.js
@@ -1,4 +1,5 @@
-const { toHaveBodyEquals } = require('../../../src');
+const { matchers } = require('../../../src');
+const { toHaveBodyEquals } = matchers;
 const { describe, before, it } = require('node:test');
 const { buildServer } = require('../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/data/toHaveBodyMatchObject.test.js
+++ b/test/matchers/data/toHaveBodyMatchObject.test.js
@@ -1,4 +1,5 @@
-const { toHaveBodyMatchObject } = require('../../../src');
+const { matchers } = require('../../../src');
+const { toHaveBodyMatchObject } = matchers;
 const { describe, before, it } = require('node:test');
 const { buildServer } = require('../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/headers/toHaveHeader.test.js
+++ b/test/matchers/headers/toHaveHeader.test.js
@@ -1,4 +1,5 @@
-const { toHaveHeader } = require('../../../src');
+const { matchers } = require('../../../src');
+const { toHaveHeader } = matchers;
 const { describe, before, it } = require('node:test');
 const { buildServer } = require('../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/generic/toBeSuccessful.test.js
+++ b/test/matchers/status/generic/toBeSuccessful.test.js
@@ -1,4 +1,5 @@
-const { toBeSuccessful } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toBeSuccessful } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/generic/toHave2xxStatus.test.js
+++ b/test/matchers/status/generic/toHave2xxStatus.test.js
@@ -1,4 +1,5 @@
-const { toHave2xxStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHave2xxStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/generic/toHave3xxStatus.test.js
+++ b/test/matchers/status/generic/toHave3xxStatus.test.js
@@ -1,4 +1,5 @@
-const { toHave3xxStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHave3xxStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/generic/toHave4xxStatus.test.js
+++ b/test/matchers/status/generic/toHave4xxStatus.test.js
@@ -1,4 +1,5 @@
-const { toHave4xxStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHave4xxStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/generic/toHave5xxStatus.test.js
+++ b/test/matchers/status/generic/toHave5xxStatus.test.js
@@ -1,4 +1,5 @@
-const { toHave5xxStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHave5xxStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/generic/toHaveStatus.test.js
+++ b/test/matchers/status/generic/toHaveStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveAcceptedStatus.test.js
+++ b/test/matchers/status/specific/toHaveAcceptedStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveAcceptedStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveAcceptedStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveBadGatewayStatus.test.js
+++ b/test/matchers/status/specific/toHaveBadGatewayStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveBadGatewayStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveBadGatewayStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveBadRequestStatus.test.js
+++ b/test/matchers/status/specific/toHaveBadRequestStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveBadRequestStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveBadRequestStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveConflictStatus.test.js
+++ b/test/matchers/status/specific/toHaveConflictStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveConflictStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveConflictStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveCreatedStatus.test.js
+++ b/test/matchers/status/specific/toHaveCreatedStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveCreatedStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveCreatedStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveExpectationFailedStatus.test.js
+++ b/test/matchers/status/specific/toHaveExpectationFailedStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveExpectationFailedStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveExpectationFailedStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveFailedDependencyStatus.test.js
+++ b/test/matchers/status/specific/toHaveFailedDependencyStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveFailedDependencyStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveFailedDependencyStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveForbiddenStatus.test.js
+++ b/test/matchers/status/specific/toHaveForbiddenStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveForbiddenStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveForbiddenStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveGatewayTimeoutStatus.test.js
+++ b/test/matchers/status/specific/toHaveGatewayTimeoutStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveGatewayTimeoutStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveGatewayTimeoutStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveGoneStatus.test.js
+++ b/test/matchers/status/specific/toHaveGoneStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveGoneStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveGoneStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveHttpVersionNotSupportedStatus.test.js
+++ b/test/matchers/status/specific/toHaveHttpVersionNotSupportedStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveHttpVersionNotSupportedStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveHttpVersionNotSupportedStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveImATeapotStatus.test.js
+++ b/test/matchers/status/specific/toHaveImATeapotStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveImATeapotStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveImATeapotStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveInsufficientSpaceOnResourceStatus.test.js
+++ b/test/matchers/status/specific/toHaveInsufficientSpaceOnResourceStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveInsufficientSpaceOnResourceStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveInsufficientSpaceOnResourceStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveInsufficientStorageStatus.test.js
+++ b/test/matchers/status/specific/toHaveInsufficientStorageStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveInsufficientStorageStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveInsufficientStorageStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveInternalServerErrorStatus.test.js
+++ b/test/matchers/status/specific/toHaveInternalServerErrorStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveInternalServerErrorStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveInternalServerErrorStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveLengthRequiredStatus.test.js
+++ b/test/matchers/status/specific/toHaveLengthRequiredStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveLengthRequiredStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveLengthRequiredStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveLockedStatus.test.js
+++ b/test/matchers/status/specific/toHaveLockedStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveLockedStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveLockedStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveMethodFailureStatus.test.js
+++ b/test/matchers/status/specific/toHaveMethodFailureStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveMethodFailureStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveMethodFailureStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveMethodNotAllowedStatus.test.js
+++ b/test/matchers/status/specific/toHaveMethodNotAllowedStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveMethodNotAllowedStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveMethodNotAllowedStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveMisdirectedRequestStatus.test.js
+++ b/test/matchers/status/specific/toHaveMisdirectedRequestStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveMisdirectedRequestStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveMisdirectedRequestStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveMovedPermanentlyStatus.test.js
+++ b/test/matchers/status/specific/toHaveMovedPermanentlyStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveMovedPermanentlyStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveMovedPermanentlyStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveMovedTemporarilyStatus.test.js
+++ b/test/matchers/status/specific/toHaveMovedTemporarilyStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveMovedTemporarilyStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveMovedTemporarilyStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveMultiStatusStatus.test.js
+++ b/test/matchers/status/specific/toHaveMultiStatusStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveMultiStatusStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveMultiStatusStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveMultipleChoicesStatus.test.js
+++ b/test/matchers/status/specific/toHaveMultipleChoicesStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveMultipleChoicesStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveMultipleChoicesStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveNetworkAuthenticationRequiredStatus.test.js
+++ b/test/matchers/status/specific/toHaveNetworkAuthenticationRequiredStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveNetworkAuthenticationRequiredStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveNetworkAuthenticationRequiredStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveNoContentStatus.test.js
+++ b/test/matchers/status/specific/toHaveNoContentStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveNoContentStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveNoContentStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveNonAuthoritativeInformationStatus.test.js
+++ b/test/matchers/status/specific/toHaveNonAuthoritativeInformationStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveNonAuthoritativeInformationStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveNonAuthoritativeInformationStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveNotAcceptableStatus.test.js
+++ b/test/matchers/status/specific/toHaveNotAcceptableStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveNotAcceptableStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveNotAcceptableStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveNotFoundStatus.test.js
+++ b/test/matchers/status/specific/toHaveNotFoundStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveNotFoundStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveNotFoundStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveNotImplementedStatus.test.js
+++ b/test/matchers/status/specific/toHaveNotImplementedStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveNotImplementedStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveNotImplementedStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveNotModifiedStatus.test.js
+++ b/test/matchers/status/specific/toHaveNotModifiedStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveNotModifiedStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveNotModifiedStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveOkStatus.test.js
+++ b/test/matchers/status/specific/toHaveOkStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveOkStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveOkStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHavePartialContentStatus.test.js
+++ b/test/matchers/status/specific/toHavePartialContentStatus.test.js
@@ -1,4 +1,5 @@
-const { toHavePartialContentStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHavePartialContentStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHavePaymentRequiredStatus.test.js
+++ b/test/matchers/status/specific/toHavePaymentRequiredStatus.test.js
@@ -1,4 +1,5 @@
-const { toHavePaymentRequiredStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHavePaymentRequiredStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHavePermanentRedirectStatus.test.js
+++ b/test/matchers/status/specific/toHavePermanentRedirectStatus.test.js
@@ -1,4 +1,5 @@
-const { toHavePermanentRedirectStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHavePermanentRedirectStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHavePreconditionFailedStatus.test.js
+++ b/test/matchers/status/specific/toHavePreconditionFailedStatus.test.js
@@ -1,4 +1,5 @@
-const { toHavePreconditionFailedStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHavePreconditionFailedStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHavePreconditionRequiredStatus.test.js
+++ b/test/matchers/status/specific/toHavePreconditionRequiredStatus.test.js
@@ -1,4 +1,5 @@
-const { toHavePreconditionRequiredStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHavePreconditionRequiredStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveProxyAuthenticationRequiredStatus.test.js
+++ b/test/matchers/status/specific/toHaveProxyAuthenticationRequiredStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveProxyAuthenticationRequiredStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveProxyAuthenticationRequiredStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveRequestHeaderFieldsTooLargeStatus.test.js
+++ b/test/matchers/status/specific/toHaveRequestHeaderFieldsTooLargeStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveRequestHeaderFieldsTooLargeStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveRequestHeaderFieldsTooLargeStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveRequestTimeoutStatus.test.js
+++ b/test/matchers/status/specific/toHaveRequestTimeoutStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveRequestTimeoutStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveRequestTimeoutStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveRequestTooLongStatus.test.js
+++ b/test/matchers/status/specific/toHaveRequestTooLongStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveRequestTooLongStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveRequestTooLongStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveRequestUriTooLongStatus.test.js
+++ b/test/matchers/status/specific/toHaveRequestUriTooLongStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveRequestUriTooLongStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveRequestUriTooLongStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveRequestedRangeNotSatisfiableStatus.test.js
+++ b/test/matchers/status/specific/toHaveRequestedRangeNotSatisfiableStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveRequestedRangeNotSatisfiableStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveRequestedRangeNotSatisfiableStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveResetContentStatus.test.js
+++ b/test/matchers/status/specific/toHaveResetContentStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveResetContentStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveResetContentStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveSeeOtherStatus.test.js
+++ b/test/matchers/status/specific/toHaveSeeOtherStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveSeeOtherStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveSeeOtherStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveServiceUnavailableStatus.test.js
+++ b/test/matchers/status/specific/toHaveServiceUnavailableStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveServiceUnavailableStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveServiceUnavailableStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveSwitchingProtocolsStatus.test.js
+++ b/test/matchers/status/specific/toHaveSwitchingProtocolsStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveSwitchingProtocolsStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveSwitchingProtocolsStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveTemporaryRedirectStatus.test.js
+++ b/test/matchers/status/specific/toHaveTemporaryRedirectStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveTemporaryRedirectStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveTemporaryRedirectStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveTooManyRequestsStatus.test.js
+++ b/test/matchers/status/specific/toHaveTooManyRequestsStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveTooManyRequestsStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveTooManyRequestsStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveUnauthorizedStatus.test.js
+++ b/test/matchers/status/specific/toHaveUnauthorizedStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveUnauthorizedStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveUnauthorizedStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveUnavailableForLegalReasonsStatus.test.js
+++ b/test/matchers/status/specific/toHaveUnavailableForLegalReasonsStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveUnavailableForLegalReasonsStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveUnavailableForLegalReasonsStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveUnprocessableEntityStatus.test.js
+++ b/test/matchers/status/specific/toHaveUnprocessableEntityStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveUnprocessableEntityStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveUnprocessableEntityStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveUnsupportedMediaTypeStatus.test.js
+++ b/test/matchers/status/specific/toHaveUnsupportedMediaTypeStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveUnsupportedMediaTypeStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveUnsupportedMediaTypeStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveUpgradeRequiredStatus.test.js
+++ b/test/matchers/status/specific/toHaveUpgradeRequiredStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveUpgradeRequiredStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveUpgradeRequiredStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/test/matchers/status/specific/toHaveUseProxyStatus.test.js
+++ b/test/matchers/status/specific/toHaveUseProxyStatus.test.js
@@ -1,4 +1,5 @@
-const { toHaveUseProxyStatus } = require('../../../../src');
+const { matchers } = require('../../../../src');
+const { toHaveUseProxyStatus } = matchers;
 const { describe, test, before } = require('node:test');
 const { buildServer } = require('../../../helpers/server-helper.js');
 const { expect, JestAssertionError } = require('expect');

--- a/types-test/expect-type-tests/setup.ts
+++ b/types-test/expect-type-tests/setup.ts
@@ -1,6 +1,6 @@
 import 'expect-http-client-matchers/expect.d.ts';
 
 import expect from 'expect';
-import {matchers} from 'expect-http-client-matchers';
+import { matchers } from 'expect-http-client-matchers';
 
 expect.extend(matchers);

--- a/types-test/expect-type-tests/setup.ts
+++ b/types-test/expect-type-tests/setup.ts
@@ -1,6 +1,6 @@
 import 'expect-http-client-matchers/expect.d.ts';
 
 import expect from 'expect';
-import * as matchers from 'expect-http-client-matchers';
+import {matchers} from 'expect-http-client-matchers';
 
 expect.extend(matchers);

--- a/types-test/jest-partial-type-tests/setup.ts
+++ b/types-test/jest-partial-type-tests/setup.ts
@@ -1,7 +1,7 @@
 import 'expect-http-client-matchers/jest.d.ts';
 
 import { matchers } from 'expect-http-client-matchers';
-const {toBeSuccessful} = matchers;
+const { toBeSuccessful } = matchers;
 
 expect.extend({
   toBeSuccessful,

--- a/types-test/jest-partial-type-tests/setup.ts
+++ b/types-test/jest-partial-type-tests/setup.ts
@@ -1,6 +1,7 @@
 import 'expect-http-client-matchers/jest.d.ts';
 
-import { toBeSuccessful } from 'expect-http-client-matchers';
+import { matchers } from 'expect-http-client-matchers';
+const {toBeSuccessful} = matchers;
 
 expect.extend({
   toBeSuccessful,

--- a/types-test/vitest-partial-type-tests/setup.ts
+++ b/types-test/vitest-partial-type-tests/setup.ts
@@ -1,4 +1,5 @@
-import { toBeSuccessful } from 'expect-http-client-matchers';
+import { matchers } from 'expect-http-client-matchers';
+const {toBeSuccessful} = matchers;
 
 expect.extend({
   toBeSuccessful,

--- a/types-test/vitest-partial-type-tests/setup.ts
+++ b/types-test/vitest-partial-type-tests/setup.ts
@@ -1,5 +1,5 @@
 import { matchers } from 'expect-http-client-matchers';
-const {toBeSuccessful} = matchers;
+const { toBeSuccessful } = matchers;
 
 expect.extend({
   toBeSuccessful,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,3 @@
 declare module 'expect-http-client-matchers' {
-  const matchers: import('./shared').CustomMatchers<any>;
-  export = matchers;
+  export const matchers: import('./shared').CustomMatchers<any>;
 }


### PR DESCRIPTION
this is needed as we will can now add custom functions to export

BREAKING CHANGE: You will need to change from:

```js
import * as matchers from 'expect-http-client-matchers';
```

To:
```js
import { matchers } from 'expect-http-client-matchers';
```

